### PR TITLE
Configure AVS Data 

### DIFF
--- a/contracts/script/RegisterOperator.s.sol
+++ b/contracts/script/RegisterOperator.s.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.12;
 import {Test, console} from "forge-std/Test.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {Script} from "forge-std/Script.sol";
-import {ISignatureUtilsMixin,ISignatureUtilsMixinTypes} from "@eigenlayer/contracts/interfaces/ISignatureUtilsMixin.sol";
+import {
+    ISignatureUtilsMixin, ISignatureUtilsMixinTypes
+} from "@eigenlayer/contracts/interfaces/ISignatureUtilsMixin.sol";
 import {IBLSApkRegistryTypes} from "@eigenlayer-middleware/src/interfaces/IBLSApkRegistry.sol";
 import {BN254} from "@eigenlayer-middleware/src/libraries/BN254.sol";
 import {IRegistryCoordinator} from "@eigenlayer-middleware/src/interfaces/IRegistryCoordinator.sol";
@@ -13,7 +15,10 @@ import {SlashingRegistryCoordinator} from "@eigenlayer-middleware/src/SlashingRe
 import {BN256G2} from "../src/libraries/BN256G2.sol";
 import {IAVSDirectory} from "@eigenlayer/contracts/interfaces/IAVSDirectory.sol";
 import {stdJson} from "forge-std/StdJson.sol";
-import {ISlashingRegistryCoordinator, ISlashingRegistryCoordinatorTypes} from "@eigenlayer-middleware/src/interfaces/ISlashingRegistryCoordinator.sol";
+import {
+    ISlashingRegistryCoordinator,
+    ISlashingRegistryCoordinatorTypes
+} from "@eigenlayer-middleware/src/interfaces/ISlashingRegistryCoordinator.sol";
 import {IAllocationManager, IAllocationManagerTypes} from "@eigenlayer/contracts/interfaces/IAllocationManager.sol";
 import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategy.sol";
 import {OperatorSet} from "@eigenlayer/contracts/libraries/OperatorSetLib.sol";
@@ -39,7 +44,6 @@ contract RegisterOperator is Script {
     using BN254 for BN254.G1Point;
     using stdJson for string;
 
-
     // Core contracts
     address constant DELEGATION_MANAGER_ADDRESS_HOLESKY = 0xA44151489861Fe9e3055d95adC98FbD462B948e7;
     address constant AVS_DIRECTORY_ADDRESS_HOLESKY = 0x055733000064333CaDDbC92763c58BF0192fFeBf;
@@ -53,7 +57,6 @@ contract RegisterOperator is Script {
 
     address registryCoordinatorMimicOwner = makeAddr("registryCoordinatorMimicOwner");
 
-
     struct Operator {
         address operator;
         uint256 ecdsaPrivateKey;
@@ -61,6 +64,7 @@ contract RegisterOperator is Script {
         BN254.G1Point pk1;
         BN254.G2Point pk2;
     }
+
     function run() public {
         string memory ecdsaPrivateKey = vm.readFile("./private.ecdsa.json");
         uint256 ecdsaPrivateKeyUint = ecdsaPrivateKey.readUint(".privateKey");
@@ -71,7 +75,8 @@ contract RegisterOperator is Script {
         BN254.G1Point memory pk1 = BN254.scalar_mul(BN254.generatorG1(), blsPrivateKeyUint);
         BN254.G2Point memory g2 = BN254.generatorG2();
         BN254.G2Point memory pk2;
-        (pk2.X[1], pk2.X[0], pk2.Y[1], pk2.Y[0]) = BN256G2.ECTwistMul(blsPrivateKeyUint, g2.X[1], g2.X[0], g2.Y[1], g2.Y[0]);
+        (pk2.X[1], pk2.X[0], pk2.Y[1], pk2.Y[0]) =
+            BN256G2.ECTwistMul(blsPrivateKeyUint, g2.X[1], g2.X[0], g2.Y[1], g2.Y[0]);
 
         // ensure correct encoding by checking pairing
         bool result = BN254.pairing(pk1, BN254.negGeneratorG2(), BN254.generatorG1(), pk2);
@@ -89,6 +94,7 @@ contract RegisterOperator is Script {
         registerOperator(IRegistryCoordinator(registryCoordinator), serviceManager, operator);
         vm.stopBroadcast();
     }
+
     function registerOperator(IRegistryCoordinator registryCoordinator, address avs, Operator memory operator)
         internal
     {
@@ -103,16 +109,14 @@ contract RegisterOperator is Script {
             pubkeyG2: operator.pk2,
             pubkeyRegistrationSignature: sig
         });
-        ISlashingRegistryCoordinatorTypes.RegistrationType registrationType = ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL;
+        ISlashingRegistryCoordinatorTypes.RegistrationType registrationType =
+            ISlashingRegistryCoordinatorTypes.RegistrationType.NORMAL;
         bytes memory encodedParams = abi.encode(registrationType, socket, params);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = 0;
 
-        IAllocationManagerTypes.RegisterParams memory registerParams = IAllocationManagerTypes.RegisterParams({
-            avs: avs,
-            operatorSetIds: operatorSetIds,
-            data: encodedParams
-        });
+        IAllocationManagerTypes.RegisterParams memory registerParams =
+            IAllocationManagerTypes.RegisterParams({avs: avs, operatorSetIds: operatorSetIds, data: encodedParams});
 
         IStrategy[] memory strategies = new IStrategy[](1);
         strategies[0] = IStrategy(LST_STRATEGY_ADDRESS_HOLESKY);
@@ -123,10 +127,7 @@ contract RegisterOperator is Script {
 
         IAllocationManagerTypes.AllocateParams[] memory allocationMods = new IAllocationManagerTypes.AllocateParams[](1);
         allocationMods[0] = IAllocationManagerTypes.AllocateParams({
-            operatorSet: OperatorSet({
-                avs: avs,
-                id: 0
-            }),
+            operatorSet: OperatorSet({avs: avs, id: 0}),
             strategies: strategies,
             newMagnitudes: newMagnitudes
         });
@@ -135,8 +136,7 @@ contract RegisterOperator is Script {
         vm.roll(block.number + 1); // Workaround for testnet, txs can't be in the same block
 
         IAllocationManager(registryCoordinator.allocationManager()).registerForOperatorSets(
-            operator.operator,
-            registerParams
+            operator.operator, registerParams
         );
     }
 

--- a/contracts/script/SetupMiddleware.s.sol
+++ b/contracts/script/SetupMiddleware.s.sol
@@ -5,7 +5,11 @@ import {Script} from "forge-std/Script.sol";
 import {IncredibleSquaringDeploymentLib} from "../script/utils/IncredibleSquaringDeploymentLib.sol";
 import {IStrategy} from "@eigenlayer/contracts/interfaces/IStrategyManager.sol";
 import {CoreDeploymentLib} from "./utils/CoreDeploymentLib.sol";
-import {AllocationManager, IAllocationManager, IAllocationManagerTypes} from "@eigenlayer/contracts/core/AllocationManager.sol";
+import {
+    AllocationManager,
+    IAllocationManager,
+    IAllocationManagerTypes
+} from "@eigenlayer/contracts/core/AllocationManager.sol";
 import {
     ISlashingRegistryCoordinator,
     ISlashingRegistryCoordinatorTypes
@@ -17,12 +21,12 @@ contract SetupMiddleware is Script {
     IncredibleSquaringDeploymentLib.DeploymentData internal deploymentData;
     CoreDeploymentLib.DeploymentData internal coreData;
 
-    // Configuration struct to hold quorum parameters
+    // Configuration struct to hold quorum parameters with proper types
     struct QuorumConfig {
-        uint256 minimumStake;
-        uint256 maxOperatorCount;
-        uint256 kickBIPsOfOperatorStake;
-        uint256 kickBIPsOfTotalStake;
+        uint96 minimumStake;
+        uint32 maxOperatorCount;
+        uint16 kickBIPsOfOperatorStake;
+        uint16 kickBIPsOfTotalStake;
         string metadataURI;
     }
 
@@ -34,23 +38,29 @@ contract SetupMiddleware is Script {
     }
 
     /**
-     * @notice Reads quorum configuration from config.json
+     * @notice Reads quorum configuration from docker/eigenlayer/config.json
+     * @dev Minimum stake and other quorum parameters are configured in docker/eigenlayer/config.json.
+     *      To change the minimum stake, edit the "minimumStake" field in that file.
+     *      This allows for easy configuration without code changes.
      * @return config The quorum configuration parameters
      */
     function readQuorumConfig() internal view returns (QuorumConfig memory config) {
         string memory root = vm.projectRoot();
-        string memory path = string.concat(root, "docker/eigenlayer/config.json");
+        string memory path = string.concat(root, "/docker/eigenlayer/config.json");
         string memory json = vm.readFile(path);
-        
-        config.minimumStake = vm.parseJsonUint(json, "$.quorum.minimumStake");
-        config.maxOperatorCount = vm.parseJsonUint(json, "$.quorum.maxOperatorCount");
-        config.kickBIPsOfOperatorStake = vm.parseJsonUint(json, "$.quorum.kickBIPsOfOperatorStake");
-        config.kickBIPsOfTotalStake = vm.parseJsonUint(json, "$.quorum.kickBIPsOfTotalStake");
+
+        // Cast JSON values to the appropriate types
+        config.minimumStake = uint96(vm.parseJsonUint(json, "$.quorum.minimumStake"));
+        config.maxOperatorCount = uint32(vm.parseJsonUint(json, "$.quorum.maxOperatorCount"));
+        config.kickBIPsOfOperatorStake = uint16(vm.parseJsonUint(json, "$.quorum.kickBIPsOfOperatorStake"));
+        config.kickBIPsOfTotalStake = uint16(vm.parseJsonUint(json, "$.quorum.kickBIPsOfTotalStake"));
         config.metadataURI = vm.parseJsonString(json, "$.metadata.uri");
     }
 
     function run() external {
         vm.startBroadcast(deployer);
+
+        QuorumConfig memory config = readQuorumConfig();
 
         address operatorSetStrategy = 0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3;
         string memory metadataURI = config.metadataURI;
@@ -61,16 +71,15 @@ contract SetupMiddleware is Script {
         IStrategy[] memory strategies = new IStrategy[](1);
         strategies[0] = IStrategy(operatorSetStrategy);
 
-        IStakeRegistryTypes.StrategyParams[] memory strategyParamsArray = new IStakeRegistryTypes.StrategyParams[](strategies.length);
+        IStakeRegistryTypes.StrategyParams[] memory strategyParamsArray =
+            new IStakeRegistryTypes.StrategyParams[](strategies.length);
         for (uint256 i = 0; i < strategies.length; i++) {
             strategyParamsArray[i] = IStakeRegistryTypes.StrategyParams({
                 strategy: strategies[i],
-                multiplier: 1 ether  // TODO: needs oracle
+                multiplier: 1 ether
             });
         }
 
-        QuorumConfig memory config = readQuorumConfig();
-        
         ISlashingRegistryCoordinator(deploymentData.slashingRegistryCoordinator).createSlashableStakeQuorum(
             ISlashingRegistryCoordinatorTypes.OperatorSetParam({
                 maxOperatorCount: config.maxOperatorCount,

--- a/contracts/script/SetupMiddleware.s.sol
+++ b/contracts/script/SetupMiddleware.s.sol
@@ -17,6 +17,15 @@ contract SetupMiddleware is Script {
     IncredibleSquaringDeploymentLib.DeploymentData internal deploymentData;
     CoreDeploymentLib.DeploymentData internal coreData;
 
+    // Configuration struct to hold quorum parameters
+    struct QuorumConfig {
+        uint256 minimumStake;
+        uint256 maxOperatorCount;
+        uint256 kickBIPsOfOperatorStake;
+        uint256 kickBIPsOfTotalStake;
+        string metadataURI;
+    }
+
     function setUp() public virtual {
         deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
         vm.label(deployer, "Deployer");
@@ -24,11 +33,27 @@ contract SetupMiddleware is Script {
         coreData = CoreDeploymentLib.readDeploymentJson("script/deployments/core/", block.chainid);
     }
 
+    /**
+     * @notice Reads quorum configuration from config.json
+     * @return config The quorum configuration parameters
+     */
+    function readQuorumConfig() internal view returns (QuorumConfig memory config) {
+        string memory root = vm.projectRoot();
+        string memory path = string.concat(root, "docker/eigenlayer/config.json");
+        string memory json = vm.readFile(path);
+        
+        config.minimumStake = vm.parseJsonUint(json, "$.quorum.minimumStake");
+        config.maxOperatorCount = vm.parseJsonUint(json, "$.quorum.maxOperatorCount");
+        config.kickBIPsOfOperatorStake = vm.parseJsonUint(json, "$.quorum.kickBIPsOfOperatorStake");
+        config.kickBIPsOfTotalStake = vm.parseJsonUint(json, "$.quorum.kickBIPsOfTotalStake");
+        config.metadataURI = vm.parseJsonString(json, "$.metadata.uri");
+    }
+
     function run() external {
         vm.startBroadcast(deployer);
 
         address operatorSetStrategy = 0x7D704507b76571a51d9caE8AdDAbBFd0ba0e63d3;
-        string memory metadataURI = "metadataURI";
+        string memory metadataURI = config.metadataURI;
 
         IAllocationManager(coreData.allocationManager).updateAVSMetadataURI(
             deploymentData.incredibleSquaringServiceManager, metadataURI
@@ -43,13 +68,16 @@ contract SetupMiddleware is Script {
                 multiplier: 1 ether  // TODO: needs oracle
             });
         }
+
+        QuorumConfig memory config = readQuorumConfig();
+        
         ISlashingRegistryCoordinator(deploymentData.slashingRegistryCoordinator).createSlashableStakeQuorum(
             ISlashingRegistryCoordinatorTypes.OperatorSetParam({
-                maxOperatorCount: 32,
-                kickBIPsOfOperatorStake: 10000,  // TODO: chosen arbitrarily
-                kickBIPsOfTotalStake: 100  // TODO: chosen arbitrarily
+                maxOperatorCount: config.maxOperatorCount,
+                kickBIPsOfOperatorStake: config.kickBIPsOfOperatorStake,
+                kickBIPsOfTotalStake: config.kickBIPsOfTotalStake
             }),
-            1, //TODO fix this to a real min
+            config.minimumStake,
             strategyParamsArray,
             0
         );

--- a/contracts/script/SetupMiddleware.s.sol
+++ b/contracts/script/SetupMiddleware.s.sol
@@ -74,10 +74,7 @@ contract SetupMiddleware is Script {
         IStakeRegistryTypes.StrategyParams[] memory strategyParamsArray =
             new IStakeRegistryTypes.StrategyParams[](strategies.length);
         for (uint256 i = 0; i < strategies.length; i++) {
-            strategyParamsArray[i] = IStakeRegistryTypes.StrategyParams({
-                strategy: strategies[i],
-                multiplier: 1 ether
-            });
+            strategyParamsArray[i] = IStakeRegistryTypes.StrategyParams({strategy: strategies[i], multiplier: 1 ether});
         }
 
         ISlashingRegistryCoordinator(deploymentData.slashingRegistryCoordinator).createSlashableStakeQuorum(

--- a/contracts/script/utils/IncredibleSquaringDeploymentLib.sol
+++ b/contracts/script/utils/IncredibleSquaringDeploymentLib.sol
@@ -147,7 +147,6 @@ library IncredibleSquaringDeploymentLib {
             )
         );
 
-
         IStrategy[] memory deployedStrategyArray = new IStrategy[](1);
         deployedStrategyArray[0] = IStrategy(strategy);
         uint256 numStrategies = deployedStrategyArray.length;
@@ -242,7 +241,8 @@ library IncredibleSquaringDeploymentLib {
         UpgradeableProxyLib.upgrade(result.socketRegistry, socketRegistryImpl);
         RegistryCoordinator(result.slashingRegistryCoordinator).unpause(0);
 
-        IAllocationManagerTypes.CreateSetParams[] memory createSetParams = new IAllocationManagerTypes.CreateSetParams[](1);
+        IAllocationManagerTypes.CreateSetParams[] memory createSetParams =
+            new IAllocationManagerTypes.CreateSetParams[](1);
         IStrategy[] memory strategies = new IStrategy[](deployedStrategyArray.length);
         for (uint256 i = 0; i < deployedStrategyArray.length; i++) {
             strategies[i] = deployedStrategyArray[i];


### PR DESCRIPTION
Adds ability to configure everything in this struct 

`struct QuorumConfig {
        uint96 minimumStake;
        uint32 maxOperatorCount;
        uint16 kickBIPsOfOperatorStake;
        uint16 kickBIPsOfTotalStake;
        string metadataURI;
    }`
    
PR in other repo: https://github.com/BreadchainCoop/eigenlayer-bls-local/pull/6

closes #2  closes #8 