### PR TITLE
Remove commonware contracts submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "contracts/lib/commonware-restaking-contracts"]
 	path = contracts/lib/commonware-restaking-contracts
 	url = https://github.com/BreadchainCoop/commonware-restaking-contracts
+	branch = bagelface/add-service-manager-wrapper

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,3 @@
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
 	url = https://github.com/layr-labs/eigenlayer-middleware.git
-[submodule "contracts/lib/commonware-restaking-contracts"]
-	path = contracts/lib/commonware-restaking-contracts
-	url = https://github.com/BreadchainCoop/commonware-restaking-contracts
-	branch = bagelface/add-service-manager-wrapper

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "contracts/lib/eigenlayer-middleware"]
 	path = contracts/lib/eigenlayer-middleware
 	url = https://github.com/layr-labs/eigenlayer-middleware.git
-[submodule "contracts/lib/avs-commonware-counter"]
-	path = contracts/lib/avs-commonware-counter
-	url = https://github.com/BreadchainCoop/avs-commonware-counter
+[submodule "contracts/lib/commonware-restaking-contracts"]
+	path = contracts/lib/commonware-restaking-contracts
+	url = https://github.com/BreadchainCoop/commonware-restaking-contracts


### PR DESCRIPTION
Was only used in "eigenlayer-bls-local" eigenlayer scripts, but we can just clone the contract repo directly instead of via submodules (which were causing dependency recursion errors when setup correctly).

This PR should be merged first https://github.com/BreadchainCoop/eigenlayer-bls-local/pull/32