### PR TITLE
security: remove plaintext private keys from `incredible_squaring_config.json`

### DIFF
--- a/contracts/incredible_squaring_config.json
+++ b/contracts/incredible_squaring_config.json
@@ -4,10 +4,10 @@
     "operator_addr": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     "operator_2_addr":"0x0b065a0423f076a340f37e16e1ce22e23d66caf2",
     "contracts_registry_addr": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-    "task_generator_addr": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-    "aggregator_addr":"0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
-    "rewards_owner_addr": "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f",
-    "rewards_initiator_addr": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
-    "rewards_owner_key": "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
-    "rewards_initiator_key": "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+    "task_generator_addr": "0x000000000000000000000000000000000DEAD6a5",
+    "aggregator_addr":"0x000000000000000000000000000000000DEAD6a5",
+    "rewards_owner_addr": "0x000000000000000000000000000000000DEAD6a5",
+    "rewards_initiator_addr": "0x000000000000000000000000000000000DEAD6a5",
+    "rewards_owner_key": "0x0",
+    "rewards_initiator_key": "0x0"
 }


### PR DESCRIPTION
## Summary

- Replaces committed plaintext Anvil private keys (`rewards_owner_key`, `rewards_initiator_key`) with `0x0` — these fields are parsed by `IncredibleSquaringDeploymentLib` but never forwarded to any contract call, so zeroing them is safe
- Replaces Anvil test addresses for `aggregator_addr`, `task_generator_addr`, `rewards_owner_addr`, and `rewards_initiator_addr` with the vanity burn address `0x000000000000000000000000000000000DEAD6a5` — these roles guard `IncredibleSquaringTaskManager.createNewTask`/`respondToTask`, which are IncredibleSquaring template artifacts never called by the Gas Killer service at runtime

## Context

`IncredibleSquaringTaskManager` is a setup-only artifact inherited from the EigenLayer IncredibleSquaring template. The Gas Killer service exclusively calls `verifyAndUpdate` on consumer contracts via `GasKillerSDK`; the task manager roles are never exercised post-deployment. The rewards key fields exist in the config struct but are read-and-discarded with no downstream use.

Closes gas-killer/service#226